### PR TITLE
Add disclaimer to footer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -96,12 +96,13 @@
     <footer class="footer">
       <div class="footer-content">
         <div class="footer-left">
-          <span class="footer-text">Powered by GitHub Actions + Pages</span>
+          <span class="footer-text">Powered by GitHub Actions</span>
         </div>
         <div class="footer-right">
           <span class="footer-text">Auto-refreshing every 60s</span>
         </div>
       </div>
+      <p class="footer-disclaimer">Information on this dashboard is provided "as is" for general informational purposes only. No representations or warranties of any kind are made regarding completeness, accuracy, reliability, or suitability, and we are not liable for any losses arising from its use.</p>
     </footer>
   </div>
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -428,7 +428,7 @@ a.bilingual-text {
 }
 
 /* Footer */
-.footer {
+.footer { 
   border-top: 1px solid var(--color-border-subtle);
   padding: var(--space-6) 0;
   margin-top: auto;
@@ -447,6 +447,14 @@ a.bilingual-text {
   color: var(--color-text-tertiary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
+}
+
+.footer-disclaimer {
+  margin-top: var(--space-4);
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  color: var(--color-text-tertiary);
+  line-height: 1.4;
 }
 
 /* Responsive design */


### PR DESCRIPTION
## Summary
- update the footer attribution to drop the GitHub Pages reference while keeping the refresh notice
- add an informational disclaimer to the bottom of the dashboard
- style the new disclaimer text to match the existing theme

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68d35e5426e083219319e4c41959f23d