### PR TITLE
Add Chinese translation for footer disclaimer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -103,6 +103,7 @@
         </div>
       </div>
       <p class="footer-disclaimer">Information on this dashboard is provided "as is" for general informational purposes only. No representations or warranties of any kind are made regarding completeness, accuracy, reliability, or suitability, and we are not liable for any losses arising from its use.</p>
+      <p class="footer-disclaimer">本仪表板所提供的信息仅按“原样”提供，供一般信息参考之用。我们不就其完整性、准确性、可靠性或适用性作出任何形式的陈述或保证，对于因使用该信息而产生的任何损失，我们概不承担责任。</p>
     </footer>
   </div>
 


### PR DESCRIPTION
## Summary
- add a Chinese-language version of the existing footer disclaimer so both languages appear at the bottom of the page

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d362f78c40832195643b5e80ea88c3