### PR TITLE
Fix TianAPI Baidu collector request payload

### DIFF
--- a/collectors/baidu_top.py
+++ b/collectors/baidu_top.py
@@ -96,14 +96,17 @@ def fetch_baidu_top(max_items: int = 10):
 
     url = "https://apis.tianapi.com/baiduhot/index"
     headers = base_headers()
-    headers.setdefault("Accept", "application/json")
+    # Force JSON responses from TianAPI – ``setdefault`` would keep the
+    # broader ``Accept`` header provided by ``base_headers``.
+    headers["Accept"] = "application/json"
 
     # TianAPI recently switched a number of endpoints to POST-only.  We
     # optimistically try a POST first and gracefully fall back to GET so the
     # collector keeps working even if the API flips between the two modes.
+    request_payload = {"key": api_key}
     request_strategies = (
-        ("post", {"data": {"key": api_key, "num": max(1, min(max_items, 50))}}),
-        ("get", {"params": {"key": api_key, "num": max(1, min(max_items, 50))}}),
+        ("post", {"data": request_payload.copy()}),
+        ("get", {"params": request_payload.copy()}),
     )
 
     for attempt in range(3):


### PR DESCRIPTION
## Summary
- ensure the Baidu TianAPI collector explicitly requests JSON responses
- reuse a shared key-only payload for both POST and GET requests so the API returns items again

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4d4e98f448321a906350cb500d067