### PR TITLE
Fix TianAPI Baidu collector syntax error

### DIFF
--- a/collectors/baidu_top.py
+++ b/collectors/baidu_top.py
@@ -94,7 +94,8 @@ def fetch_baidu_top(max_items: int = 10):
         print("Warning: TIANAPI_API_KEY not found in environment variables")
         return []
 
-    url = "https://apis.tianapi.com/hotword/index"    headers = base_headers()
+    url = "https://apis.tianapi.com/hotword/index"
+    headers = base_headers()
     # Force JSON responses from TianAPI – ``setdefault`` would keep the
     # broader ``Accept`` header provided by ``base_headers``.
     headers["Accept"] = "application/json"


### PR DESCRIPTION
## Summary
- split the TianAPI Baidu collector URL and headers assignments onto separate lines to restore valid syntax
- ensure the collector can execute without raising a syntax error while retaining existing TianAPI logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5a533aae88321b114606f7b222ee3