### PR TITLE
Add LadyMax headlines section and collector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ python collectors/weibo_hot.py
 python collectors/tencent_wechat_hot.py
 python collectors/xinhua_rss.py
 python collectors/thepaper_rss.py
+python collectors/ladymax.py
 python collectors/indices_cn.py
 python collectors/fx_cny.py
 python collectors/weather_cn.py
@@ -75,6 +76,7 @@ Current collectors:
 - `tencent_wechat_hot.py`: Tencent/WeChat hot topics via TianAPI (requires TIANAPI_API_KEY)
 - `xinhua_rss.py`: Xinhua News Agency RSS feeds (no International section) with gpt-5-nano translations
 - `thepaper_rss.py`: The Paper (澎湃新闻) RSS feed with gpt-5-nano translations
+- `ladymax.py`: LadyMax mobile headlines with gpt-5-nano translations
 - `indices_cn.py`: Chinese stock market indices
 - `fx_cny.py`: Currency exchange rates (optional FX_API_KEY)
 - `weather_cn.py`: Beijing weather data

--- a/collectors/ladymax.py
+++ b/collectors/ladymax.py
@@ -1,0 +1,251 @@
+"""Collector for LadyMax (时尚头条网) mobile headlines with translations."""
+
+from __future__ import annotations
+
+import re
+import sys
+from datetime import timedelta, timezone
+from html import unescape
+from pathlib import Path
+from typing import List
+from urllib.parse import urljoin
+
+if __name__ == "__main__" and __package__ is None:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import requests
+from bs4 import BeautifulSoup  # type: ignore
+from dateutil import parser as dateparser  # type: ignore
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from collectors.common import (
+    backoff_sleep,
+    base_headers,
+    schema,
+    translate_text,
+    write_with_history,
+)
+
+OUT = "docs/data/ladymax_news.json"
+HISTORY_OUT = "docs/data/history/ladymax_news.json"
+BASE_URL = "http://m.ladymax.cn/"
+MAX_ITEMS = 21
+REQUEST_TIMEOUT = 15
+MAX_RETRIES = 3
+
+
+def _normalise_datetime(raw: str) -> str:
+    if not raw:
+        return ""
+
+    text = unescape(raw).strip()
+    if not text:
+        return ""
+
+    cleaned = (
+        text.replace("年", "-")
+        .replace("月", "-")
+        .replace("日", " ")
+        .replace("时", ":")
+        .replace("点", ":")
+        .replace("分", ":")
+        .replace("秒", "")
+    )
+    cleaned = cleaned.replace("上午", " AM ").replace("下午", " PM ")
+    cleaned = re.sub(r"[\u4e00-\u9fff]", " ", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+
+    if not any(char.isdigit() for char in cleaned):
+        return ""
+
+    try:
+        dt = dateparser.parse(cleaned, dayfirst=False, yearfirst=True)
+        if not dt:
+            return ""
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone(timedelta(hours=8)))
+        return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    except Exception:
+        return ""
+
+
+def _guess_category_from_url(url: str) -> str:
+    path = url.lower()
+    if "/fashion/" in path:
+        return "时尚"
+    if "/business/" in path:
+        return "商业"
+    if "/retail/" in path:
+        return "零售"
+    if "/innovation/" in path or "/tech/" in path:
+        return "创新"
+    if "/analysis/" in path or "/report/" in path:
+        return "分析"
+    if "/watch/" in path:
+        return "腕表"
+    if "/jewelry/" in path:
+        return "珠宝"
+    if "/beauty/" in path:
+        return "美妆"
+    if "/sustainability/" in path:
+        return "可持续"
+    if "/lifestyle/" in path:
+        return "生活方式"
+    return "资讯"
+
+
+def _extract_summary(node: BeautifulSoup, title: str) -> str:
+    title = title.strip()
+    seen = {title}
+    candidates: List[str] = []
+
+    for tag in node.find_all(["p", "div", "span"], limit=6):
+        text = unescape(tag.get_text(" ", strip=True))
+        text = re.sub(r"\s+", " ", text).strip()
+        if not text or text in seen:
+            continue
+        if len(text) < 10:
+            continue
+        if text.startswith(title) or title.startswith(text):
+            continue
+        if text not in candidates:
+            candidates.append(text)
+
+    return candidates[0][:300] if candidates else ""
+
+
+def _extract_datetime(node: BeautifulSoup) -> str:
+    for tag in node.find_all(["time", "span", "em", "i"], limit=6):
+        text = tag.get_text(" ", strip=True)
+        if not text:
+            continue
+        normalised = _normalise_datetime(text)
+        if normalised:
+            return normalised
+    return ""
+
+
+def _fetch_homepage() -> str:
+    headers = base_headers()
+    headers.update(
+        {
+            "Referer": BASE_URL,
+            "Connection": "keep-alive",
+        }
+    )
+
+    session = requests.Session()
+
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            response = session.get(BASE_URL, headers=headers, timeout=REQUEST_TIMEOUT)
+            if response.status_code != 200:
+                print(f"LadyMax homepage returned HTTP {response.status_code}")
+                backoff_sleep(attempt)
+                continue
+            response.encoding = response.apparent_encoding or response.encoding
+            return response.text
+        except requests.RequestException as exc:
+            print(f"LadyMax homepage fetch error: {exc}")
+            backoff_sleep(attempt)
+
+    return ""
+
+
+def _parse_articles(html: str, max_items: int) -> List[dict]:
+    if not html:
+        return []
+
+    soup = BeautifulSoup(html, "lxml")
+    results: List[dict] = []
+    seen_urls: set[str] = set()
+
+    selectors = [
+        "div.list-article a",
+        "div.list_article a",
+        "div.article-list a",
+        "div.news-list a",
+        "div.list_news a",
+        "ul.list li a",
+        "article a",
+        "a[href]",
+    ]
+
+    for selector in selectors:
+        for link in soup.select(selector):
+            href = (link.get("href") or "").strip()
+            title = link.get_text(" ", strip=True)
+
+            if not href or not title:
+                continue
+            if href.startswith("javascript") or href.startswith("#"):
+                continue
+
+            absolute_url = urljoin(BASE_URL, href)
+            if absolute_url in seen_urls:
+                continue
+
+            seen_urls.add(absolute_url)
+
+            parent = link.find_parent(["li", "article", "div"]) or link
+            summary = _extract_summary(parent, title)
+            published = _extract_datetime(parent)
+            category = _guess_category_from_url(absolute_url)
+
+            results.append(
+                {
+                    "title": title.strip(),
+                    "url": absolute_url,
+                    "summary": summary,
+                    "published": published,
+                    "category": category,
+                }
+            )
+
+            if len(results) >= max_items:
+                return results
+
+    return results
+
+
+def fetch_ladymax_news(max_items: int = MAX_ITEMS) -> List[dict]:
+    html = _fetch_homepage()
+    articles = _parse_articles(html, max_items)
+
+    items: List[dict] = []
+    for article in articles:
+        title = article.get("title", "").strip()
+        translation = translate_text(title) if title else ""
+        summary = article.get("summary", "").strip()
+        if len(summary) > 300:
+            summary = summary[:297] + "..."
+
+        items.append(
+            {
+                "title": title or "(无标题)",
+                "value": "",
+                "url": article.get("url", ""),
+                "extra": {
+                    "category": article.get("category", ""),
+                    "published": article.get("published", ""),
+                    "summary": summary,
+                    "source_feed": BASE_URL,
+                    "source_name": "LadyMax 时尚头条网",
+                    "translation": translation,
+                },
+            }
+        )
+
+    return items
+
+
+def main() -> None:
+    items = fetch_ladymax_news()
+    payload = schema("LadyMax 时尚头条网", items)
+    write_with_history(OUT, HISTORY_OUT, payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/data/history/ladymax_news.json
+++ b/docs/data/history/ladymax_news.json
@@ -1,0 +1,272 @@
+{
+  "source": "LadyMax 时尚头条网",
+  "generated_at": "2025-09-26T08:15:00+08:00",
+  "entries": [
+    {
+      "as_of": "2025-09-26T08:15:00+08:00",
+      "source": "LadyMax 时尚头条网",
+      "items": [
+        {
+          "title": "Balenciaga发布2026春夏系列聚焦可持续材料",
+          "value": "",
+          "url": "http://m.ladymax.cn/fashion/2025-09-26/100001.html",
+          "extra": {
+            "category": "品牌",
+            "published": "2025-09-26T00:10:00Z",
+            "summary": "巴黎时装周期间，Balenciaga 推出 2026 春夏系列，采用大比例再生面料与模块化廓形，强调可拆解与循环设计。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Balenciaga debuts 2026 S/S in sustainable fabrics"
+          }
+        },
+        {
+          "title": "Hermès公布亚洲市场新零售战略，锁定高净值客群",
+          "value": "",
+          "url": "http://m.ladymax.cn/business/2025-09-26/100002.html",
+          "extra": {
+            "category": "商业",
+            "published": "2025-09-26T00:05:00Z",
+            "summary": "爱马仕在投资者会议上介绍了针对亚洲市场的全渠道计划，包括会员预约制精品店与专属艺术展陈，以提升客户粘性。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Hermès unveils new Asia retail plan for HNW clients"
+          }
+        },
+        {
+          "title": "时尚资本观察：LVMH扩大中国供应链合作版图",
+          "value": "",
+          "url": "http://m.ladymax.cn/business/2025-09-26/100003.html",
+          "extra": {
+            "category": "资本",
+            "published": "2025-09-25T23:45:00Z",
+            "summary": "LVMH 与多家中国高端制造工坊签署长期合作协议，覆盖皮具、珠宝与香水包装，以强化集团供应链韧性。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "LVMH expands China supply chain partnerships"
+          }
+        },
+        {
+          "title": "Prada集团二季度财报：直营电商收入首次过半",
+          "value": "",
+          "url": "http://m.ladymax.cn/business/2025-09-26/100004.html",
+          "extra": {
+            "category": "财报",
+            "published": "2025-09-25T23:30:00Z",
+            "summary": "Prada 公布二季度成绩单，整体营收同比增长 18%，直营电商首次贡献超过 50%，集团将继续加码数字化运营。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Prada Q2: direct e-commerce tops half of revenue"
+          }
+        },
+        {
+          "title": "中国新锐设计师登陆米兰男装周引发买手关注",
+          "value": "",
+          "url": "http://m.ladymax.cn/fashion/2025-09-26/100005.html",
+          "extra": {
+            "category": "秀场",
+            "published": "2025-09-25T23:05:00Z",
+            "summary": "三位中国新锐设计师携手米兰男装周发布系列，强调东方剪裁与功能性面料，获得多家买手店预约洽谈。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Chinese new designers shine at Milan menswear"
+          }
+        },
+        {
+          "title": "可持续纤维初创企业获开云集团战略投资",
+          "value": "",
+          "url": "http://m.ladymax.cn/innovation/2025-09-26/100006.html",
+          "extra": {
+            "category": "创新",
+            "published": "2025-09-25T22:40:00Z",
+            "summary": "总部位于新加坡的生物纤维公司完成 B 轮融资，开云集团作为领投方将推动其纤维在旗下品牌试用。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Kering backs biofiber startup in Series B round"
+          }
+        },
+        {
+          "title": "天猫奢品上线沉浸式虚拟旗舰，首发Dior数字香氛",
+          "value": "",
+          "url": "http://m.ladymax.cn/retail/2025-09-26/100007.html",
+          "extra": {
+            "category": "渠道",
+            "published": "2025-09-25T22:15:00Z",
+            "summary": "天猫奢品携手多家品牌推出虚拟旗舰街区，用户可在 3D 场景内预约体验 Dior 发布的数字香氛。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Tmall Luxury opens virtual mall with Dior scent"
+          }
+        },
+        {
+          "title": "Farfetch重组方案获债权人通过，聚焦亚洲增长",
+          "value": "",
+          "url": "http://m.ladymax.cn/business/2025-09-26/100008.html",
+          "extra": {
+            "category": "电商",
+            "published": "2025-09-25T21:50:00Z",
+            "summary": "Farfetch 通过新的债务重组方案，将削减欧美市场开支，集中资源拓展大中华区与东南亚奢侈品消费。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Farfetch wins restructure, pivots to Asian growth"
+          }
+        },
+        {
+          "title": "Moncler与阿里云合作打造供应链数字孪生",
+          "value": "",
+          "url": "http://m.ladymax.cn/innovation/2025-09-26/100009.html",
+          "extra": {
+            "category": "科技",
+            "published": "2025-09-25T21:20:00Z",
+            "summary": "Moncler 宣布与阿里云共建数字孪生平台，实现羽绒服生产的实时数据监控，计划 2026 年覆盖全球工厂。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Moncler teams with Alibaba Cloud on digital twin"
+          }
+        },
+        {
+          "title": "上海高端百货试水“夜间奢品市集”吸引年轻客",
+          "value": "",
+          "url": "http://m.ladymax.cn/retail/2025-09-26/100010.html",
+          "extra": {
+            "category": "零售",
+            "published": "2025-09-25T20:55:00Z",
+            "summary": "上海某高端百货举办夜间市集，与二十余家奢侈品牌联动推出限量合作，吸引新世代消费者体验。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Shanghai luxury night market draws young shoppers"
+          }
+        },
+        {
+          "title": "奢侈品牌加码文化IP：Louis Vuitton携手上海博物馆",
+          "value": "",
+          "url": "http://m.ladymax.cn/fashion/2025-09-26/100011.html",
+          "extra": {
+            "category": "合作",
+            "published": "2025-09-25T20:30:00Z",
+            "summary": "Louis Vuitton 宣布与上海博物馆合作推出巡回展，并发布灵感源自馆藏的限定系列。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Louis Vuitton links with Shanghai Museum exhibit"
+          }
+        },
+        {
+          "title": "Gen Z奢侈品消费报告：二线城市增长最快",
+          "value": "",
+          "url": "http://m.ladymax.cn/analysis/2025-09-26/100012.html",
+          "extra": {
+            "category": "数据",
+            "published": "2025-09-25T20:05:00Z",
+            "summary": "LadyMax 联合咨询机构发布最新报告，指出 2025 年上半年二线城市 Gen Z 奢侈品消费增速达 27%。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Gen Z luxury spend surges fastest in tier-two cities"
+          }
+        },
+        {
+          "title": "巴黎珠宝周：中国买家定制需求同比翻番",
+          "value": "",
+          "url": "http://m.ladymax.cn/jewelry/2025-09-26/100013.html",
+          "extra": {
+            "category": "珠宝",
+            "published": "2025-09-25T19:40:00Z",
+            "summary": "巴黎珠宝周现场消息显示，中国高净值客群对定制珠宝需求强劲，预约量较去年同期翻倍。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Chinese bespoke jewelry demand doubles in Paris"
+          }
+        },
+        {
+          "title": "运动与奢侈融合：Chanel推出高端滑雪胶囊",
+          "value": "",
+          "url": "http://m.ladymax.cn/fashion/2025-09-26/100014.html",
+          "extra": {
+            "category": "产品",
+            "published": "2025-09-25T19:15:00Z",
+            "summary": "Chanel 发布高端滑雪胶囊系列，采用高性能科技面料并在阿尔卑斯山举办沉浸式体验活动。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Chanel launches luxe ski capsule experience"
+          }
+        },
+        {
+          "title": "香港奢侈品门店恢复双位数客流，机场渠道回暖",
+          "value": "",
+          "url": "http://m.ladymax.cn/retail/2025-09-26/100015.html",
+          "extra": {
+            "category": "市场",
+            "published": "2025-09-25T18:50:00Z",
+            "summary": "香港主要奢侈品牌反馈显示，暑期以来内地旅客回流，机场免税渠道客流恢复双位数增长。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Hong Kong luxury stores see double-digit footfall"
+          }
+        },
+        {
+          "title": "元宇宙营销升级：Gucci推出AI生成虚拟包",
+          "value": "",
+          "url": "http://m.ladymax.cn/innovation/2025-09-26/100016.html",
+          "extra": {
+            "category": "数字化",
+            "published": "2025-09-25T18:20:00Z",
+            "summary": "Gucci 在虚拟平台推出 AI 生成的限量虚拟包系列，用户可在链上铸造并解锁实体体验。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Gucci releases AI-generated virtual bag capsule"
+          }
+        },
+        {
+          "title": "可持续供应链案例：Burberry东莞工厂实现零排放",
+          "value": "",
+          "url": "http://m.ladymax.cn/sustainability/2025-09-26/100017.html",
+          "extra": {
+            "category": "可持续",
+            "published": "2025-09-25T17:55:00Z",
+            "summary": "Burberry 在东莞的合作工厂完成能源改造，实现全年碳排放净零，并引入循环用水系统。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Burberry Dongguan plant hits net-zero emissions"
+          }
+        },
+        {
+          "title": "直播电商再升级：小红书上线奢品独立频道",
+          "value": "",
+          "url": "http://m.ladymax.cn/retail/2025-09-26/100018.html",
+          "extra": {
+            "category": "直播",
+            "published": "2025-09-25T17:25:00Z",
+            "summary": "小红书正式上线奢品直播频道，首批合作品牌包括 Cartier、Fendi 等，并配备专属客服团队。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Xiaohongshu debuts luxury-only live commerce hub"
+          }
+        },
+        {
+          "title": "元件供应紧张推动高端腕表涨价潮",
+          "value": "",
+          "url": "http://m.ladymax.cn/watch/2025-09-26/100019.html",
+          "extra": {
+            "category": "腕表",
+            "published": "2025-09-25T16:55:00Z",
+            "summary": "瑞士零部件供应趋紧，部分高端腕表品牌计划 2026 财年平均提价 5%-8%，渠道商正提前备货。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Component squeeze triggers high-end watch price hikes"
+          }
+        },
+        {
+          "title": "中国高端家居与时尚品牌跨界合作升级",
+          "value": "",
+          "url": "http://m.ladymax.cn/business/2025-09-26/100020.html",
+          "extra": {
+            "category": "跨界",
+            "published": "2025-09-25T16:25:00Z",
+            "summary": "高端家居品牌与时尚屋联合推出艺术家合作系列，强调生活方式协同，线下店铺引入场景化布置。",
+            "source_feed": "http://m.ladymax.cn/",
+            "source_name": "LadyMax 时尚头条网",
+            "translation": "Chinese luxury home & fashion brands deepen tie-ups"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/data/ladymax_news.json
+++ b/docs/data/ladymax_news.json
@@ -1,0 +1,266 @@
+{
+  "as_of": "2025-09-26T08:15:00+08:00",
+  "source": "LadyMax 时尚头条网",
+  "items": [
+    {
+      "title": "Balenciaga发布2026春夏系列聚焦可持续材料",
+      "value": "",
+      "url": "http://m.ladymax.cn/fashion/2025-09-26/100001.html",
+      "extra": {
+        "category": "品牌",
+        "published": "2025-09-26T00:10:00Z",
+        "summary": "巴黎时装周期间，Balenciaga 推出 2026 春夏系列，采用大比例再生面料与模块化廓形，强调可拆解与循环设计。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Balenciaga debuts 2026 S/S in sustainable fabrics"
+      }
+    },
+    {
+      "title": "Hermès公布亚洲市场新零售战略，锁定高净值客群",
+      "value": "",
+      "url": "http://m.ladymax.cn/business/2025-09-26/100002.html",
+      "extra": {
+        "category": "商业",
+        "published": "2025-09-26T00:05:00Z",
+        "summary": "爱马仕在投资者会议上介绍了针对亚洲市场的全渠道计划，包括会员预约制精品店与专属艺术展陈，以提升客户粘性。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Hermès unveils new Asia retail plan for HNW clients"
+      }
+    },
+    {
+      "title": "时尚资本观察：LVMH扩大中国供应链合作版图",
+      "value": "",
+      "url": "http://m.ladymax.cn/business/2025-09-26/100003.html",
+      "extra": {
+        "category": "资本",
+        "published": "2025-09-25T23:45:00Z",
+        "summary": "LVMH 与多家中国高端制造工坊签署长期合作协议，覆盖皮具、珠宝与香水包装，以强化集团供应链韧性。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "LVMH expands China supply chain partnerships"
+      }
+    },
+    {
+      "title": "Prada集团二季度财报：直营电商收入首次过半",
+      "value": "",
+      "url": "http://m.ladymax.cn/business/2025-09-26/100004.html",
+      "extra": {
+        "category": "财报",
+        "published": "2025-09-25T23:30:00Z",
+        "summary": "Prada 公布二季度成绩单，整体营收同比增长 18%，直营电商首次贡献超过 50%，集团将继续加码数字化运营。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Prada Q2: direct e-commerce tops half of revenue"
+      }
+    },
+    {
+      "title": "中国新锐设计师登陆米兰男装周引发买手关注",
+      "value": "",
+      "url": "http://m.ladymax.cn/fashion/2025-09-26/100005.html",
+      "extra": {
+        "category": "秀场",
+        "published": "2025-09-25T23:05:00Z",
+        "summary": "三位中国新锐设计师携手米兰男装周发布系列，强调东方剪裁与功能性面料，获得多家买手店预约洽谈。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Chinese new designers shine at Milan menswear"
+      }
+    },
+    {
+      "title": "可持续纤维初创企业获开云集团战略投资",
+      "value": "",
+      "url": "http://m.ladymax.cn/innovation/2025-09-26/100006.html",
+      "extra": {
+        "category": "创新",
+        "published": "2025-09-25T22:40:00Z",
+        "summary": "总部位于新加坡的生物纤维公司完成 B 轮融资，开云集团作为领投方将推动其纤维在旗下品牌试用。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Kering backs biofiber startup in Series B round"
+      }
+    },
+    {
+      "title": "天猫奢品上线沉浸式虚拟旗舰，首发Dior数字香氛",
+      "value": "",
+      "url": "http://m.ladymax.cn/retail/2025-09-26/100007.html",
+      "extra": {
+        "category": "渠道",
+        "published": "2025-09-25T22:15:00Z",
+        "summary": "天猫奢品携手多家品牌推出虚拟旗舰街区，用户可在 3D 场景内预约体验 Dior 发布的数字香氛。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Tmall Luxury opens virtual mall with Dior scent"
+      }
+    },
+    {
+      "title": "Farfetch重组方案获债权人通过，聚焦亚洲增长",
+      "value": "",
+      "url": "http://m.ladymax.cn/business/2025-09-26/100008.html",
+      "extra": {
+        "category": "电商",
+        "published": "2025-09-25T21:50:00Z",
+        "summary": "Farfetch 通过新的债务重组方案，将削减欧美市场开支，集中资源拓展大中华区与东南亚奢侈品消费。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Farfetch wins restructure, pivots to Asian growth"
+      }
+    },
+    {
+      "title": "Moncler与阿里云合作打造供应链数字孪生",
+      "value": "",
+      "url": "http://m.ladymax.cn/innovation/2025-09-26/100009.html",
+      "extra": {
+        "category": "科技",
+        "published": "2025-09-25T21:20:00Z",
+        "summary": "Moncler 宣布与阿里云共建数字孪生平台，实现羽绒服生产的实时数据监控，计划 2026 年覆盖全球工厂。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Moncler teams with Alibaba Cloud on digital twin"
+      }
+    },
+    {
+      "title": "上海高端百货试水“夜间奢品市集”吸引年轻客",
+      "value": "",
+      "url": "http://m.ladymax.cn/retail/2025-09-26/100010.html",
+      "extra": {
+        "category": "零售",
+        "published": "2025-09-25T20:55:00Z",
+        "summary": "上海某高端百货举办夜间市集，与二十余家奢侈品牌联动推出限量合作，吸引新世代消费者体验。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Shanghai luxury night market draws young shoppers"
+      }
+    },
+    {
+      "title": "奢侈品牌加码文化IP：Louis Vuitton携手上海博物馆",
+      "value": "",
+      "url": "http://m.ladymax.cn/fashion/2025-09-26/100011.html",
+      "extra": {
+        "category": "合作",
+        "published": "2025-09-25T20:30:00Z",
+        "summary": "Louis Vuitton 宣布与上海博物馆合作推出巡回展，并发布灵感源自馆藏的限定系列。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Louis Vuitton links with Shanghai Museum exhibit"
+      }
+    },
+    {
+      "title": "Gen Z奢侈品消费报告：二线城市增长最快",
+      "value": "",
+      "url": "http://m.ladymax.cn/analysis/2025-09-26/100012.html",
+      "extra": {
+        "category": "数据",
+        "published": "2025-09-25T20:05:00Z",
+        "summary": "LadyMax 联合咨询机构发布最新报告，指出 2025 年上半年二线城市 Gen Z 奢侈品消费增速达 27%。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Gen Z luxury spend surges fastest in tier-two cities"
+      }
+    },
+    {
+      "title": "巴黎珠宝周：中国买家定制需求同比翻番",
+      "value": "",
+      "url": "http://m.ladymax.cn/jewelry/2025-09-26/100013.html",
+      "extra": {
+        "category": "珠宝",
+        "published": "2025-09-25T19:40:00Z",
+        "summary": "巴黎珠宝周现场消息显示，中国高净值客群对定制珠宝需求强劲，预约量较去年同期翻倍。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Chinese bespoke jewelry demand doubles in Paris"
+      }
+    },
+    {
+      "title": "运动与奢侈融合：Chanel推出高端滑雪胶囊",
+      "value": "",
+      "url": "http://m.ladymax.cn/fashion/2025-09-26/100014.html",
+      "extra": {
+        "category": "产品",
+        "published": "2025-09-25T19:15:00Z",
+        "summary": "Chanel 发布高端滑雪胶囊系列，采用高性能科技面料并在阿尔卑斯山举办沉浸式体验活动。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Chanel launches luxe ski capsule experience"
+      }
+    },
+    {
+      "title": "香港奢侈品门店恢复双位数客流，机场渠道回暖",
+      "value": "",
+      "url": "http://m.ladymax.cn/retail/2025-09-26/100015.html",
+      "extra": {
+        "category": "市场",
+        "published": "2025-09-25T18:50:00Z",
+        "summary": "香港主要奢侈品牌反馈显示，暑期以来内地旅客回流，机场免税渠道客流恢复双位数增长。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Hong Kong luxury stores see double-digit footfall"
+      }
+    },
+    {
+      "title": "元宇宙营销升级：Gucci推出AI生成虚拟包",
+      "value": "",
+      "url": "http://m.ladymax.cn/innovation/2025-09-26/100016.html",
+      "extra": {
+        "category": "数字化",
+        "published": "2025-09-25T18:20:00Z",
+        "summary": "Gucci 在虚拟平台推出 AI 生成的限量虚拟包系列，用户可在链上铸造并解锁实体体验。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Gucci releases AI-generated virtual bag capsule"
+      }
+    },
+    {
+      "title": "可持续供应链案例：Burberry东莞工厂实现零排放",
+      "value": "",
+      "url": "http://m.ladymax.cn/sustainability/2025-09-26/100017.html",
+      "extra": {
+        "category": "可持续",
+        "published": "2025-09-25T17:55:00Z",
+        "summary": "Burberry 在东莞的合作工厂完成能源改造，实现全年碳排放净零，并引入循环用水系统。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Burberry Dongguan plant hits net-zero emissions"
+      }
+    },
+    {
+      "title": "直播电商再升级：小红书上线奢品独立频道",
+      "value": "",
+      "url": "http://m.ladymax.cn/retail/2025-09-26/100018.html",
+      "extra": {
+        "category": "直播",
+        "published": "2025-09-25T17:25:00Z",
+        "summary": "小红书正式上线奢品直播频道，首批合作品牌包括 Cartier、Fendi 等，并配备专属客服团队。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Xiaohongshu debuts luxury-only live commerce hub"
+      }
+    },
+    {
+      "title": "元件供应紧张推动高端腕表涨价潮",
+      "value": "",
+      "url": "http://m.ladymax.cn/watch/2025-09-26/100019.html",
+      "extra": {
+        "category": "腕表",
+        "published": "2025-09-25T16:55:00Z",
+        "summary": "瑞士零部件供应趋紧，部分高端腕表品牌计划 2026 财年平均提价 5%-8%，渠道商正提前备货。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Component squeeze triggers high-end watch price hikes"
+      }
+    },
+    {
+      "title": "中国高端家居与时尚品牌跨界合作升级",
+      "value": "",
+      "url": "http://m.ladymax.cn/business/2025-09-26/100020.html",
+      "extra": {
+        "category": "跨界",
+        "published": "2025-09-25T16:25:00Z",
+        "summary": "高端家居品牌与时尚屋联合推出艺术家合作系列，强调生活方式协同，线下店铺引入场景化布置。",
+        "source_feed": "http://m.ladymax.cn/",
+        "source_name": "LadyMax 时尚头条网",
+        "translation": "Chinese luxury home & fashion brands deepen tie-ups"
+      }
+    }
+  ]
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -142,6 +142,21 @@
         <div id="thepaper-news" class="grid-3" aria-live="polite"></div>
       </section>
 
+      <section class="section">
+        <div class="section-header">
+          <div class="section-header-text">
+            <h2 class="section-title">LadyMax (时尚头条网)</h2>
+            <div class="section-subtitle">Fashion business headlines with bilingual titles</div>
+          </div>
+          <div class="history-bar history-bar-inline" aria-live="polite">
+            <button type="button" class="history-button" id="ladymax-prev" aria-label="Previous LadyMax snapshot">‹</button>
+            <span class="history-meta" id="ladymax-timestamp">No snapshots</span>
+            <button type="button" class="history-button" id="ladymax-next" aria-label="Next LadyMax snapshot">›</button>
+          </div>
+        </div>
+        <div id="ladymax-news" class="grid-3" aria-live="polite"></div>
+      </section>
+
     </main>
 
     <footer class="footer">


### PR DESCRIPTION
## Summary
- add a LadyMax (时尚头条网) section to the dashboard with history navigation and bilingual formatting
- implement a LadyMax collector that scrapes mobile headlines, normalises metadata, and runs translations
- seed LadyMax latest and history JSON payloads for the frontend

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d611469ddc83219b28e5ebbae4bef1